### PR TITLE
Make gdb python support compile under Ubuntu 24

### DIFF
--- a/gdb/configure
+++ b/gdb/configure
@@ -16987,6 +16987,8 @@ build_warnings="-Wall -Wpointer-arith \
 -Wredundant-move \
 -Wmissing-declarations \
 -Wstrict-null-sentinel \
+-Wno-error=deprecated-declarations \
+-Wno-error=self-move \
 "
 
 # The -Wmissing-prototypes flag will be accepted by GCC, but results


### PR DESCRIPTION
...by disabling some error-out on warnings for
"deprecated-declarations" and "self-move"